### PR TITLE
Support returning headers, rows values as array

### DIFF
--- a/src/agGrid/agGridInteractions.js
+++ b/src/agGrid/agGridInteractions.js
@@ -65,6 +65,11 @@ export const getAgGridData = (agGridElement, options = {}) => {
   });
 }
 
+  // if options.rawValues = true, return headers & rows values as arrays instead of mapping as objects
+  if (options.valuesArray) {
+    return {headers, rows};
+  }
+
   // return structured object from headers and rows variables
   return rows.map((row) =>
     row.reduce((acc, curr, idx) => {


### PR DESCRIPTION
When options.rawValues = true, returns the headers and rows values as an array
instead of mapping each row as an object. This is useful when same header names
are used in nested headers.

Ex grid:

![image](https://user-images.githubusercontent.com/317299/124924708-57fdff00-e019-11eb-912d-5f767cbc1899.png)

Existing `cy.get("grid-selector").getAgGridData()` will result in below object for a row data, as same header names (Original, Upload, Difference) are used twice:

```
{
  Difference: "0.000"
  Feature Name: "Loan Amount"
  Original: "0.046"
  PSI: "0.000"
  Type: "Continuous"
  Upload: "0.046"
}
```

When we set `rawValues = true`, like `cy.get("grid-selector").getAgGridData({valuesArray: true})`, then it will result in `headers` and `rows` as arrays.

Ex:
```
cy.get("grid-selector")
  .getAgGridData({valuesArray: true})
  .then((headers, rows) => console.log(headers, rows)); // prints two array of values
```