### PR TITLE
 Added support for filter menu's without tabs

### DIFF
--- a/src/agGrid/agGridInteractions.js
+++ b/src/agGrid/agGridInteractions.js
@@ -369,7 +369,7 @@ export function filterByCheckboxColumnMenu(agGridElement, options) {
       const _options = populateSearchCriteria(
         _searchCriteria,
         options.hasApplyButton,
-        otions.noMenuTabs
+        options.noMenuTabs
       );
       _filterByCheckboxColumnMenu(agGridElement, _options);
     });

--- a/src/agGrid/agGridInteractions.js
+++ b/src/agGrid/agGridInteractions.js
@@ -197,7 +197,6 @@ function filterBySearchTerm(agGridElement, filterValue, operator, noMenuTabs) {
       .find("span")
       .contains(operator)
       .then(($ele) => {
-        console.log('operator element', $ele)
         //Have to use the unwrapped element, since Cypress .click() event does not appropriately select the operator
         $ele.trigger('click');
       });

--- a/src/agGrid/agGridInteractions.js
+++ b/src/agGrid/agGridInteractions.js
@@ -65,6 +65,11 @@ export const getAgGridData = (agGridElement, options = {}) => {
   });
 }
 
+  // if options.rawValues = true, return headers & rows values as arrays instead of mapping as objects
+  if (options.valuesArray) {
+    return {headers, rows};
+  }
+
   // return structured object from headers and rows variables
   return rows.map((row) =>
     row.reduce((acc, curr, idx) => {


### PR DESCRIPTION
#The ag-grid community edition does have tabs in the filter menu.
Therefore an option noMenuTabs is added to get it working with this version of ag-grid.

Fixes issue #3 