### PR TITLE
amended selector to match current grid dom

### DIFF
--- a/src/agGrid/agGridInteractions.js
+++ b/src/agGrid/agGridInteractions.js
@@ -170,7 +170,7 @@ function getFilterColumnButtonElement(
           .then(() => {
             cy.wrap($ele)
               .parents(".ag-header-row-column")
-              .siblings(".ag-header-row-floating-filter")
+              .siblings(".ag-header-row-column-filter")
               .find(`.ag-header-cell[aria-colindex=${columnIndex}]`)
               .find(".ag-floating-filter-button");
           });


### PR DESCRIPTION
the floating filter tests were failing. Dom for AG Grid had a different selector on the sibling div, amended to match current grid so that the repo tests pass.