### PR TITLE
Add localText option for select all when filtering by checkbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .idea
+cypress/screenshots
+cypress/videos

--- a/cypress/integration/ag-grid-spec.js
+++ b/cypress/integration/ag-grid-spec.js
@@ -98,6 +98,7 @@ describe("ag-grid scenarios", () => {
         columnName: "Model",
         filterValue: "2002",
       },
+      selectAllLocaleText: 'Select All', // This is optional if you are using localText for ag grid
       hasApplyButton: true,
     });
     cy.get(agGridSelector)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-ag-grid",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-ag-grid",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Cypress plugin to interact with ag grid",
   "main": "src/index.js",
   "repository": {

--- a/src/agGrid/agGridInteractions.js
+++ b/src/agGrid/agGridInteractions.js
@@ -405,9 +405,10 @@ function _filterByCheckboxColumnMenu(agGridElement, options) {
       agGridElement,
       options.searchCriteria.columnName
     ).click();
+    const selectAllText = options.selectAllLocaleText || 'Select All'
     toggleColumnCheckboxFilter(
       agGridElement,
-      "Select All",
+      selectAllText,
       false,
       options.noMenuTabs
     );


### PR DESCRIPTION
When we filter by checkbox, we first deselect the `Select All` checkbox to ensure we ONLY select the specified checkbox. Since AG grid allows for localization, we need a way to be able to pass in the localeText for `Select All`. This is the only area of this plugin that has a hard-coded value, so no other localization accommodations are needed.

This PR enables an option called `selectAlLocaleText` to pass in the localText for `Select All` in the call, like this:

```
    cy.get("#myGrid").agGridColumnFilterCheckboxMenu({
      searchCriteria: {
        columnName: "Model",
        filterValue: "2002",
      },
      selectAllLocaleText: "Tout Sélectionner"
      hasApplyButton: true,
    });
```