### PR TITLE
Merge 2.0.0-beta into master

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ Cypress plugin for interacting with and validating against ag grid.
     + [Grid Interaction](#)
         - [Getting Data From the Grid](#getting-data-from-the-grid)
         - [Getting Select Row Data](#getting-select-row-data)
+        - [Getting Elements From the Grid](#getting-elements-from-the-grid)
         - [Sorting Columns](#sorting-columns)
         - [Filter by Text - Column Menu](#filter-by-text---column-menu)
         - [Filterby Text - Floating Filter](#filterby-text---floating-filter)
         - [Filter by Checkbox - Column Menu](#filter-by-checkbox---column-menu)
+        - [Filtering - Localization and Internationalization](#filtering---localization-and-internationalization)
         - [Add or Remove Columns](#add-or-remove-columns)
     + [Grid Validation](#)
         - [Validate Paginated Table](#validate-paginated-table)
@@ -83,6 +85,25 @@ The above command will return the follwoing:
     { "Year": "2020", "Make": "Mercedes"},
 ]
 ```
+</br>
+</br>
+
+### Getting Elements From the Grid
+To get the Ag Grid data as elements (if you want to interact with the cells themselves), you must chain `.getAgGridElements()` after the `cy.get()` command for the topmost level of the grid, including controls and headers (see selected DOM element in above image).
+```javascript
+    cy.get(agGridSelector)
+      .getAgGridElements()
+      .then((tableElements) => {
+        const porscheRow = tableElements.find(
+          (row) => row.Price.innerText === "72000"
+        );
+        const priceCell = porscheRow.Price;
+        cy.wrap(priceCell).dblclick().type("66000{enter}");
+      });
+
+```
+
+The above example will grab the table as elements, finds the row whose `Price` equals `72000`. It then gets the `Price` cell for that row, double clicks on it to enable an editable input, and changes the value of the cell.
 </br>
 </br>
 
@@ -194,6 +215,20 @@ Example:
 
 ```
 </br>
+
+### Filtering - Localization and Internationalization
+When we filter by checkbox, we first deselect the Select All checkbox to ensure we ONLY select the specified checkbox. Since AG grid allows for localization, we need a way to be able to pass in the localeText for Select All. This is the only area of this plugin that has a hard-coded value, so no other localization accommodations are needed.
+
+```
+    cy.get("#myGrid").agGridColumnFilterCheckboxMenu({
+      searchCriteria: {
+        columnName: "Model",
+        filterValue: "2002",
+      },
+      selectAllLocaleText: "Tout Sélectionner"
+      hasApplyButton: true,
+    });
+```   
 </br>
 
 ### Add or Remove Columns

--- a/app/grid-basic.js
+++ b/app/grid-basic.js
@@ -47,7 +47,7 @@ new agGrid.Grid(eGridDiv, gridOptions);
 // Grab the grid data from the supplied API endpoint
 agGrid
   .simpleHttpRequest({
-    url: "https://api.jsonbin.io/v3/b/608304f69a9aa933335613a6/2"
+    url: "https://api.jsonbin.io/v3/b/608304f69a9aa933335613a6/2",
   })
   .then((data) => {
     gridOptions.api.setRowData(data.record);

--- a/app/grid-basic.js
+++ b/app/grid-basic.js
@@ -1,0 +1,70 @@
+// specify the columns
+const columnDefs = [
+  { field: "year", pinned: "left" },
+  { field: "make", rowGroup: false, pinned: "left" },
+  { field: "model", filter: true },
+  { field: "price", pinned: "right", floatingFilter: false, sortable: false, editable: true, cellEditor: 'agTextCellEditor'  },
+];
+
+const autoGroupColumnDef = {
+  headerName: "Model",
+  field: "model",
+  cellRenderer: "agGroupCellRenderer",
+  cellRendererParams: {
+    checkbox: true,
+  },
+};
+
+// let the grid know which columns to use
+const gridOptions = {
+  defaultColDef: {
+    sortable: true,
+    filter: "agTextColumnFilter",
+    floatingFilter: true,
+    filterParams: {
+      buttons: ["reset", "apply"],
+      debounceMs: 200,
+    },
+    animateRows: true,
+    resizable: true,
+  },
+  autoGroupColumnDef: autoGroupColumnDef,
+  groupSelectsChildren: true,
+  columnDefs: columnDefs,
+  rowSelection: "multiple",
+  domLayout: "normal",
+  pagination: true,
+  paginationPageSize: 5,
+  sideBar: true,
+};
+
+// lookup the container we want the Grid to use
+const eGridDiv = document.querySelector("#myGrid");
+
+// create the grid passing in the div to use together with the columns &amp; data we want to use
+new agGrid.Grid(eGridDiv, gridOptions);
+
+// Grab the grid data from the supplied API endpoint
+agGrid
+  .simpleHttpRequest({
+    url: "https://api.jsonbin.io/v3/b/608304f69a9aa933335613a6/2"
+  })
+  .then((data) => {
+    gridOptions.api.setRowData(data.record);
+  });
+
+function autoSizeAllColumns() {
+  var allColumnIds = [];
+  gridOptions.columnApi.getAllColumns().forEach(function (column) {
+    allColumnIds.push(column.colId);
+  });
+  gridOptions.columnApi.autoSizeColumns(allColumnIds);
+}
+
+// If the Cypress test is running, ensure all columns fit within the window
+if (window.Cypress) {
+  gridOptions.api.sizeColumnsToFit();
+} else {
+    // Otherwise auto-size columns the way we wish to view the grid in production.
+    autoSizeAllColumns();
+}

--- a/app/grid-grouped.js
+++ b/app/grid-grouped.js
@@ -1,7 +1,7 @@
 // specify the columns
 const columnDefsGrouped = [
   { field: "year", pivot: true, },
-  { field: "make", rowGroup: true, enableRowGroup: true, aggFunc: 'sum' },
+  { field: "make", rowGroup: true, enableRowGroup: true },
   { field: "model", filter: true },
   { field: "price", editable: true, cellEditor: 'agTextCellEditor'  },
 ];
@@ -48,10 +48,10 @@ new agGrid.Grid(eGridDivGrouped, gridOptionsGrouped);
 // Grab the grid data from the supplied API endpoint
 agGrid
   .simpleHttpRequest({
-    url: "https://api.jsonbin.io/b/608304f69a9aa933335613a6/2",
+    url: "https://api.jsonbin.io/v3/b/608304f69a9aa933335613a6/2",
   })
   .then((data) => {
-    gridOptionsGrouped.api.setRowData(data);
+    gridOptionsGrouped.api.setRowData(data.record);
   });
 
 function autoSizeAllColumns() {

--- a/app/grid-grouped.js
+++ b/app/grid-grouped.js
@@ -1,12 +1,12 @@
 // specify the columns
-const columnDefs = [
-  { field: "year", pinned: "left" },
-  { field: "make", rowGroup: false, pinned: "left" },
+const columnDefsGrouped = [
+  { field: "year", pivot: true, },
+  { field: "make", rowGroup: true, enableRowGroup: true, aggFunc: 'sum' },
   { field: "model", filter: true },
-  { field: "price", pinned: "right", floatingFilter: false, sortable: false },
+  { field: "price", editable: true, cellEditor: 'agTextCellEditor'  },
 ];
 
-const autoGroupColumnDef = {
+const autoGroupColumnDefGrouped = {
   headerName: "Model",
   field: "model",
   cellRenderer: "agGroupCellRenderer",
@@ -16,7 +16,7 @@ const autoGroupColumnDef = {
 };
 
 // let the grid know which columns to use
-const gridOptions = {
+const gridOptionsGrouped = {
   defaultColDef: {
     sortable: true,
     filter: "agTextColumnFilter",
@@ -28,42 +28,43 @@ const gridOptions = {
     animateRows: true,
     resizable: true,
   },
-  autoGroupColumnDef: autoGroupColumnDef,
+  groupDefaultExpanded: 2,
+  autoGroupColumnDef: autoGroupColumnDefGrouped,
   groupSelectsChildren: true,
-  columnDefs: columnDefs,
+  columnDefs: columnDefsGrouped,
   rowSelection: "multiple",
   domLayout: "normal",
   pagination: true,
   paginationPageSize: 5,
-  sideBar: true,
+  sideBar: false,
 };
 
 // lookup the container we want the Grid to use
-const eGridDiv = document.querySelector("#myGrid");
+const eGridDivGrouped = document.querySelector("#myGrid2");
 
 // create the grid passing in the div to use together with the columns &amp; data we want to use
-new agGrid.Grid(eGridDiv, gridOptions);
+new agGrid.Grid(eGridDivGrouped, gridOptionsGrouped);
 
 // Grab the grid data from the supplied API endpoint
 agGrid
   .simpleHttpRequest({
-    url: "https://api.jsonbin.io/v3/b/608304f69a9aa933335613a6/2"
+    url: "https://api.jsonbin.io/b/608304f69a9aa933335613a6/2",
   })
   .then((data) => {
-    gridOptions.api.setRowData(data.record);
+    gridOptionsGrouped.api.setRowData(data);
   });
 
 function autoSizeAllColumns() {
   var allColumnIds = [];
-  gridOptions.columnApi.getAllColumns().forEach(function (column) {
+  gridOptionsGrouped.columnApi.getAllColumns().forEach(function (column) {
     allColumnIds.push(column.colId);
   });
-  gridOptions.columnApi.autoSizeColumns(allColumnIds);
+  gridOptionsGrouped.columnApi.autoSizeColumns(allColumnIds);
 }
 
 // If the Cypress test is running, ensure all columns fit within the window
 if (window.Cypress) {
-  gridOptions.api.sizeColumnsToFit();
+  gridOptionsGrouped.api.sizeColumnsToFit();
 } else {
     // Otherwise auto-size columns the way we wish to view the grid in production.
     autoSizeAllColumns();

--- a/app/index.html
+++ b/app/index.html
@@ -7,7 +7,9 @@
 </head>
 <body>
   <div id="myGrid" style="height: 600px;width:900px;" class="ag-theme-alpine" sideBar="true"></div>
-  <script src="grid.js" type="text/javascript" charset="utf-8">
-</script>
+  <script src="grid-basic.js" type="text/javascript" charset="utf-8"></script>
+
+  <div id="myGrid2" style="height: 600px;width:900px;" class="ag-theme-alpine" sideBar="true"></div>
+  <script src="grid-grouped.js" type="text/javascript" charset="utf-8"></script>
 </body>
 </html>

--- a/cypress/e2e/ag-grid-data.cy.js
+++ b/cypress/e2e/ag-grid-data.cy.js
@@ -104,7 +104,7 @@ describe("ag-grid get data scenarios", () => {
     cy.get(agGridSelector)
       .getAgGridData()
       .then((actualTableData) => {
-        cy.get(agGridSelector).agGridValidateRowsExactOrder(actualTableData, expectedTableData)
+        cy.agGridValidateRowsExactOrder(actualTableData, expectedTableData);
       });
   });
 
@@ -130,11 +130,7 @@ describe("ag-grid get data scenarios", () => {
     cy.get(agGridSelector)
       .getAgGridData()
       .then((actualTableData) => {
-        cy.get(agGridSelector).agGridValidateRowsExactOrder(
-          actualTableData,
-          expectedTableData,
-          true
-        );
+        cy.agGridValidateRowsExactOrder(actualTableData, expectedTableData, true);
       });
   });
 
@@ -156,7 +152,7 @@ describe("ag-grid get data scenarios", () => {
     cy.get(agGridSelector)
       .getAgGridData()
       .then((actualTableData) => {
-        cy.get(agGridSelector).agGridValidateRowsExactOrder(actualTableData, expectedTableData);
+        cy.agGridValidateRowsExactOrder(actualTableData, expectedTableData);
       });
   });
 
@@ -183,7 +179,7 @@ describe("ag-grid get data scenarios", () => {
     cy.get(agGridSelector)
       .getAgGridData()
       .then((actualTableData) => {
-        cy.get(agGridSelector).agGridValidateRowsExactOrder(actualTableData, expectedTableData);
+        cy.agGridValidateRowsExactOrder(actualTableData, expectedTableData);
       });
   });
 
@@ -205,7 +201,7 @@ describe("ag-grid get data scenarios", () => {
     cy.get(agGridSelector)
       .getAgGridData()
       .then((actualTableData) => {
-        cy.get(agGridSelector).agGridValidateRowsExactOrder(actualTableData, expectedTableData);
+        cy.agGridValidateRowsExactOrder(actualTableData, expectedTableData);
       });
   });
 
@@ -235,7 +231,7 @@ describe("ag-grid get data scenarios", () => {
     cy.get(agGridSelector)
       .getAgGridData()
       .then((actualTableData) => {
-        cy.get(agGridSelector).agGridValidateRowsExactOrder(actualTableData, expectedTableData);
+        cy.agGridValidateRowsExactOrder(actualTableData, expectedTableData);
       });
   });
 
@@ -277,7 +273,7 @@ describe("ag-grid get data scenarios", () => {
     cy.get(agGridSelector)
       .getAgGridData()
       .then((actualTableData) => {
-        cy.get(agGridSelector).agGridValidateEmptyTable(actualTableData);
+        cy.agGridValidateEmptyTable(actualTableData);
       });
   });
 
@@ -296,7 +292,7 @@ describe("ag-grid get data scenarios", () => {
       cy.get(agGridSelector)
         .getAgGridData()
         .then((actualTableData) => {
-          cy.get(agGridSelector).agGridValidateRowsExactOrder(
+          cy.agGridValidateRowsExactOrder(
             actualTableData,
             expectedData_sortedByAscending
           );
@@ -319,7 +315,7 @@ describe("ag-grid get data scenarios", () => {
       cy.get(agGridSelector)
         .getAgGridData()
         .then((actualTableData) => {
-          cy.get(agGridSelector).agGridValidateRowsExactOrder(
+          cy.agGridValidateRowsExactOrder(
             actualTableData,
             expectedData_sortedByDescending
           );
@@ -337,7 +333,7 @@ describe("ag-grid get data scenarios", () => {
       cy.get(agGridSelector)
         .getAgGridData()
         .then((actualTableData) => {
-          cy.get(agGridSelector).agGridValidateRowsExactOrder(
+          cy.agGridValidateRowsExactOrder(
             actualTableData,
             expectedData_yearColumnRemoved.slice(0, _pageSize)
           );
@@ -356,7 +352,7 @@ describe("ag-grid get data scenarios", () => {
       cy.get(agGridSelector)
         .getAgGridData()
         .then((actualTableData) => {
-          cy.get(agGridSelector).agGridValidateRowsExactOrder(
+          cy.agGridValidateRowsExactOrder(
             actualTableData,
             expectedData_priceColumnRemoved.slice(0, _pageSize)
           );
@@ -375,7 +371,7 @@ describe("ag-grid get data scenarios", () => {
       cy.get(agGridSelector)
         .getAgGridData()
         .then((actualTableData) => {
-          cy.get(agGridSelector).agGridValidateRowsExactOrder(
+          cy.agGridValidateRowsExactOrder(
             actualTableData,
             expectedData_multipleColumnsRemoved.slice(0, _pageSize)
           );
@@ -394,7 +390,7 @@ describe("ag-grid get data scenarios", () => {
     cy.get(agGridSelector)
       .getAgGridData({ onlyColumns: ["Year", "Make", "Model"] })
       .then((actualTableData) => {
-        cy.get(agGridSelector).agGridValidateRowsSubset(actualTableData, expectedTableData);
+        cy.agGridValidateRowsSubset(actualTableData, expectedTableData);
       });
   });
 });

--- a/cypress/e2e/ag-grid-elements.cy.js
+++ b/cypress/e2e/ag-grid-elements.cy.js
@@ -1,0 +1,59 @@
+import { filterOperator } from "../../src/agGrid/filterOperator.enum";
+
+const agGridSelector = "#myGrid2";
+
+describe("ag-grid get elements scenario", () => {
+  beforeEach(() => {
+    cy.visit("../app/index.html");
+    cy.get(".ag-cell", { timeout: 10000 }).should("be.visible");
+  });
+
+  it("able to update grid cell value", () => {
+    // filter to only show the porsche
+    cy.get(agGridSelector).agGridColumnFilterTextFloating({
+      searchCriteria: {
+        columnName: "Make",
+        filterValue: "Porsche",
+        operator: filterOperator.equals,
+      },
+      hasApplyButton: true,
+    });
+
+    // expected values before changing the price
+    const expectedTableBeforeEditing = [
+      { Year: "2020", Make: "Porsche", Model: "Boxter", Price: "72000" },
+      { Year: "2020", Make: "Porsche", Model: "Boxter", Price: "99000" },
+    ];
+
+    // verify values before editing
+    cy.get(agGridSelector)
+      .getAgGridData()
+      .then((tableData) => {
+        cy.agGridValidateRowsSubset(tableData, expectedTableBeforeEditing);
+      });
+
+    // edit the porsche boxter from 72000 to 66000
+    cy.get(agGridSelector)
+      .getAgGridElements()
+      .then((tableElements) => {
+        const porscheRow = tableElements.find(
+          (row) => row.Price.innerText === "72000"
+        );
+        const priceCell = porscheRow.Price;
+        cy.wrap(priceCell).dblclick().type("66000{enter}");
+      });
+
+    // expected values after changing the price
+    const expectedTableAfterEditing = [
+      { Year: "2020", Make: "Porsche", Model: "Boxter", Price: "66000" },
+      { Year: "2020", Make: "Porsche", Model: "Boxter", Price: "99000" },
+    ];
+
+    // verify values before editing
+    cy.get(agGridSelector)
+      .getAgGridData()
+      .then((tableData) => {
+        cy.agGridValidateRowsSubset(tableData, expectedTableAfterEditing);
+      });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-ag-grid",
-  "version": "2.0.0-beta",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-ag-grid",
-  "version": "1.4.0",
+  "version": "2.0.0-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-ag-grid",
-  "version": "1.5.0",
+  "version": "2.0.0-beta",
   "description": "Cypress plugin to interact with ag grid",
   "main": "src/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-ag-grid",
-  "version": "2.0.0-beta",
+  "version": "1.4.0",
   "description": "Cypress plugin to interact with ag grid",
   "main": "src/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-ag-grid",
-  "version": "1.4.0",
+  "version": "2.0.0-beta",
   "description": "Cypress plugin to interact with ag grid",
   "main": "src/index.js",
   "repository": {

--- a/src/agGrid/agGridInteractions.js
+++ b/src/agGrid/agGridInteractions.js
@@ -5,9 +5,9 @@ import { filterTab } from "./menuTab.enum";
 /**
  * Uses the attribute value's index and sorts the data accordingly.
  * For our purposes, we are getting the attribute with the items' indices and sorting accordingly.
- * 
- * @param {*} index 
- * @returns 
+ *
+ * @param {*} index
+ * @returns
  */
 function sortElementsByAttributeValue(attribute) {
   return (a, b) => {
@@ -23,6 +23,19 @@ function sortElementsByAttributeValue(attribute) {
  * @param options Provide an array of columns you wish to exclude from the table retrieval.
  */
 export const getAgGridData = (agGridElement, options = {}) => {
+  return _getAgGrid(agGridElement, options, false);
+};
+
+/**
+ * Retrieves the values from the *displayed* page in ag grid and assigns each value to its respective column name.
+ * @param agGridElement The get() selector for which ag grid table you wish to retrieve.
+ * @param options Provide an array of columns you wish to exclude from the table retrieval.
+ */
+export const getAgGridElements = (agGridElement, options = {}) => {
+  return _getAgGrid(agGridElement, options, true);
+};
+
+function _getAgGrid(agGridElement, options = {}, returnElements) {
   const agGridColumnSelectors =
     ".ag-pinned-left-cols-container^.ag-center-cols-clipper^.ag-pinned-right-cols-container";
   if (agGridElement.get().length > 1)
@@ -33,45 +46,59 @@ export const getAgGridData = (agGridElement, options = {}) => {
   const tableElement = agGridElement.get()[0].querySelectorAll(".ag-root")[0];
   const agGridSelectors = agGridColumnSelectors.split("^");
   const headers = [
-    ...tableElement.querySelectorAll('.ag-header-row-column [aria-colindex]')]
-    .sort(sortElementsByAttributeValue('aria-colindex'))
+    ...tableElement.querySelectorAll(".ag-header-row-column [aria-colindex]"),
+  ]
+    .sort(sortElementsByAttributeValue("aria-colindex"))
     .map((headerElement) => {
       // Check if the elements returned are already .ag-header-cell-text elements
       // If not, query for that element and return the text content
-      let headerCells = [...headerElement.querySelectorAll(".ag-header-cell-text")]
+      let headerCells = [
+        ...headerElement.querySelectorAll(".ag-header-cell-text"),
+      ];
       if (headerCells.length === 0) {
-        return [headerElement].map((e) => e.textContent.trim())
+        return [headerElement].map((e) => e.textContent.trim());
       } else {
-        return [...headerElement.querySelectorAll(".ag-header-cell-text")]
-          .map((e) => e.textContent.trim())
+        return [...headerElement.querySelectorAll(".ag-header-cell-text")].map(
+          (e) => e.textContent.trim()
+        );
       }
-    }).flat()
+    })
+    .flat();
 
   let allRows = [];
   let rows = [];
 
   agGridSelectors.forEach((selector) => {
-    const _rows = [...tableElement.querySelectorAll(`${selector}:not(.ag-hidden) .ag-row`)]
+    const _rows = [
+      ...tableElement.querySelectorAll(`${selector}:not(.ag-hidden) .ag-row`),
+    ]
       // Sort rows by their row-index attribute value
       .sort(sortElementsByAttributeValue("row-index"))
       .map((row) => {
         // Sort row cells by their aria-colindex attribute value
         // First check if elements returned already contain the aria-colindex
         // If not, just query for the .ag-cell
-        let rowCells = [...row.querySelectorAll(".ag-cell [aria-colindex]")]
+        let rowCells = [...row.querySelectorAll(".ag-cell [aria-colindex]")];
         if (rowCells.length === 0) {
-          rowCells = [...row.querySelectorAll(".ag-cell")]
+          rowCells = [...row.querySelectorAll(".ag-cell")];
         }
-        return rowCells.sort(sortElementsByAttributeValue("aria-colindex"))
-        .map((e)=> e.textContent.trim())
+        return rowCells
+          .sort(sortElementsByAttributeValue("aria-colindex"))
+          .map((e) => {
+            if (returnElements) {
+              return e;
+            } else {
+              return e.textContent.trim();
+            }
+          });
       });
     allRows.push(_rows);
   });
 
   // Remove any empty arrays before merging
   allRows = allRows.filter(function (ele) {
-    return ele.length
-  })
+    return ele.length;
+  });
 
   if (!allRows.length) rows = [];
   else {
@@ -102,7 +129,7 @@ export const getAgGridData = (agGridElement, options = {}) => {
       return { ...acc, [headers[idx]]: curr };
     }, {})
   );
-};
+}
 
 /**
  * Retrieve the ag grid column header element based on its column name value
@@ -226,7 +253,7 @@ function getFilterColumnButtonElement(
       .contains(operator)
       .then(($ele) => {
         //Have to use the unwrapped element, since Cypress .click() event does not appropriately select the operator
-        $ele.trigger('click');
+        $ele.trigger("click");
       });
   }
   // Input filter term and allow grid a moment to render the results
@@ -246,7 +273,6 @@ function applyColumnFilter(agGridElement, hasApplyButton, noMenuTabs) {
       .find(".ag-filter-apply-panel-button")
       .contains("Apply")
       .click();
-
   }
   if (!noMenuTabs) {
     getMenuTabElement(agGridElement, filterTab.filter).click();
@@ -279,7 +305,11 @@ function toggleColumnCheckboxFilter(
     });
 }
 
-function populateSearchCriteria(searchCriteria, hasApplyButton = false, noMenuTabs = false) {
+function populateSearchCriteria(
+  searchCriteria,
+  hasApplyButton = false,
+  noMenuTabs = false
+) {
   const options = {};
   //@ts-ignore
   options.searchCriteria = {};
@@ -345,7 +375,7 @@ function _filterBySearchTextColumnMenu(agGridElement, options) {
  * @param options.searchCriteria.operator [Optional] Use if using a search operator (i.e. Less Than, Equals, etc...use filterOperator.enum values).
  * @param options.hasApplyButton [Optional] True if "Apply" button is used, false if filters by text input automatically.
  * @param options.noMenuTabs [Optional] True if you use for example the community edition of ag-grid, which has no menu tabs
-*/
+ */
 export function filterBySearchTextColumnFloatingFilter(agGridElement, options) {
   // Check if there are multiple search criteria provided by attempting to access the columnName
   if (!options.searchCriteria.columnName) {
@@ -373,7 +403,11 @@ function _filterBySearchTextColumnFloatingFilter(agGridElement, options) {
       agGridElement,
       options
     );
-    applyColumnFilter(agGridElement, options.hasApplyButton, options.noMenuTabs);
+    applyColumnFilter(
+      agGridElement,
+      options.hasApplyButton,
+      options.noMenuTabs
+    );
   });
 }
 
@@ -409,7 +443,7 @@ function _filterByCheckboxColumnMenu(agGridElement, options) {
       agGridElement,
       options.searchCriteria.columnName
     ).click();
-    const selectAllText = options.selectAllLocaleText || 'Select All'
+    const selectAllText = options.selectAllLocaleText || "Select All";
     toggleColumnCheckboxFilter(
       agGridElement,
       selectAllText,
@@ -422,7 +456,11 @@ function _filterByCheckboxColumnMenu(agGridElement, options) {
       true,
       options.noMenuTabs
     );
-    applyColumnFilter(agGridElement, options.hasApplyButton, options.noMenuTabs);
+    applyColumnFilter(
+      agGridElement,
+      options.hasApplyButton,
+      options.noMenuTabs
+    );
   });
 }
 
@@ -430,7 +468,11 @@ function _filterByCheckboxColumnMenu(agGridElement, options) {
  * Will perform a filter for all search criteria provided, then selects all found entries in the grid
  * @param searchCriteria a "\^" delimited string of all columns and searchCriteria to search for in the grid (i.e. "Name=John Smith^Rate Plan=Standard"
  */
-export function filterGridEntriesBySearchText(agGridElement, searchCriteria, isFloatingFilter = false) {
+export function filterGridEntriesBySearchText(
+  agGridElement,
+  searchCriteria,
+  isFloatingFilter = false
+) {
   if (isFloatingFilter) {
     filterBySearchTextColumnFloatingFilter(agGridElement, searchCriteria);
   } else {

--- a/src/agGrid/agGridValidations.js
+++ b/src/agGrid/agGridValidations.js
@@ -30,7 +30,7 @@ export function validateTablePages(agGridElement,expectedPaginatedTableData, onl
             .then((table) => {
                 const actualPage = JSON.parse(JSON.stringify(table));
                 validateTableExactOrder(agGridElement, actualPage, expectedPage, true);
-                cy.get(".ag-icon-next").click();
+                cy.get(agGridElement).find(".ag-icon-next").click();
                 iterator++;
             });
     });

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,7 +2,8 @@
 
 declare namespace Cypress {
     interface Chainable<Subject> {
-        getAgGridData<E extends Node = HTMLElement>(options?: {}): Chainable<JQuery<E>>;
+        getAgGridData(options?: {}): Chainable<Array<Record<string, string>>>;
+        getAgGridElements<E extends Node = HTMLElement>(options?: {}): Chainable<JQuery<E>>;
         /**
          *  * Performs sorting operation on the specified column
          * @param {*} subject The get() selector for which ag grid table you wish to retrieve.

--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,19 @@
 /// <reference types="cypress" />
 
-import {getAgGridData, sortColumnBy} from "./agGrid/agGridInteractions"
+import {getAgGridData, getAgGridElements, sortColumnBy} from "./agGrid/agGridInteractions"
 import {validateTablePages, validateTableExactOrder, validateEmptyTable, validateTableRowSubset} from "./agGrid/agGridValidations"
 import {filterByCheckboxColumnMenu, filterBySearchTextColumnFloatingFilter, filterBySearchTextColumnMenu, toggleColumnFromSideBar} from "./agGrid/agGridInteractions";
 
 Cypress.Commands.add('getAgGridData', { prevSubject: true }, getAgGridData);
+Cypress.Commands.add('getAgGridElements', {prevSubject: true}, getAgGridElements);
 Cypress.Commands.add('agGridSortColumn', {prevSubject: true}, sortColumnBy);
 Cypress.Commands.add('agGridColumnFilterCheckboxMenu', {prevSubject: true}, filterByCheckboxColumnMenu)
 Cypress.Commands.add('agGridColumnFilterTextMenu', {prevSubject: true}, filterBySearchTextColumnMenu)
 Cypress.Commands.add('agGridColumnFilterTextFloating', {prevSubject: true}, filterBySearchTextColumnFloatingFilter)
 
-Cypress.Commands.add('agGridValidatePaginatedTable', {prevSubject: true}, validateTablePages)
-Cypress.Commands.add('agGridValidateRowsExactOrder', {prevSubject: true}, validateTableExactOrder)
-Cypress.Commands.add('agGridValidateRowsSubset', {prevSubject: true}, validateTableRowSubset)
-Cypress.Commands.add('agGridValidateEmptyTable', {prevSubject: true}, validateEmptyTable)
+Cypress.Commands.add('agGridValidatePaginatedTable', {prevSubject: 'optional'}, validateTablePages)
+Cypress.Commands.add('agGridValidateRowsExactOrder', {prevSubject: 'optional'}, validateTableExactOrder)
+Cypress.Commands.add('agGridValidateRowsSubset', {prevSubject: 'optional'}, validateTableRowSubset)
+Cypress.Commands.add('agGridValidateEmptyTable', {prevSubject: 'optional'}, validateEmptyTable)
 
 Cypress.Commands.add('agGridToggleColumnsSideBar', {prevSubject: true}, toggleColumnFromSideBar)


### PR DESCRIPTION
This PR enables `getAgGridElements()` which allows us to retrieve the actual cell elements from the AG grid. 

### Getting Elements From the Grid
To get the Ag Grid data as elements (if you want to interact with the cells themselves), you must chain `.getAgGridElements()` after the `cy.get()` command for the topmost level of the grid, including controls and headers (see selected DOM element in above image).
```javascript
    cy.get(agGridSelector)
      .getAgGridElements()
      .then((tableElements) => {
        const porscheRow = tableElements.find(
          (row) => row.Price.innerText === "72000"
        );
        const priceCell = porscheRow.Price;
        cy.wrap(priceCell).dblclick().type("66000{enter}");
      });

```

The above example will grab the table as elements, finds the row whose `Price` equals `72000`. It then gets the `Price` cell for that row, double clicks on it to enable an editable input, and changes the value of the cell.
