### PR TITLE
v3.x fix duplicate entry bug

### DIFF
--- a/app/data.json
+++ b/app/data.json
@@ -18,5 +18,6 @@
         { "year": "1990", "make": "Ford", "model": "Taurus", "condition":"excellent","price": "900" },
         { "year": "2020", "make": "Hyundai", "model": "Elantra", "condition":"fair","price": "3000" },
         { "year": "2020", "make": "BMW", "model": "2002", "condition":"excellent","price": "88001" },
-        { "year": "2023", "make": "Hyundai", "model": "Santa Fe", "condition":"excellent","price": "" }
+        { "year": "2023", "make": "Hyundai", "model": "Santa Fe", "condition":"excellent","price": "" },
+        { "year": "2020", "make": "Toyota", "model": "Celica", "condition": "fair", "price": "35000" }
 ]

--- a/cypress/e2e/ag-grid-data.cy.js
+++ b/cypress/e2e/ag-grid-data.cy.js
@@ -38,6 +38,9 @@ const expectedPaginatedTableData = [
     { Year: "2020", Make: "BMW", Model: "2002", Condition: "excellent", Price: "88001" },
     { Year: "2023", Make: "Hyundai", Model: "Santa Fe", Condition: "excellent", Price: "" },
   ],
+  [
+    { Year: "2020", Make: "Toyota", Model: "Celica", Condition: "fair", Price: "35000" },
+  ]
 ];
 
 describe("ag-grid get data scenarios", () => {
@@ -45,6 +48,31 @@ describe("ag-grid get data scenarios", () => {
     cy.visit("../app/index.html");
     cy.get(".ag-cell", { timeout: 10000 }).should("be.visible");
   });
+
+  it("verify data when multiple rows are identical", ()=>{
+
+    const expectedTableData = 
+    [
+      { "Year": "2020", "Make": "Toyota", "Model": "Celica", "Condition": "fair", "Price": "35000" },
+      { "Year": "2020", "Make": "Toyota", "Model": "Celica", "Condition": "poor", "Price": "5000" },
+      { "Year": "2020", "Make": "Toyota", "Model": "Celica", "Condition": "fair", "Price": "35000" },
+    ]
+    cy.get(agGridSelector).agGridColumnFilterCheckboxMenu({
+      searchCriteria: {
+        columnName: "Model",
+        filterValue: "Celica",
+      },
+      selectAllLocaleText: "Select All", // This is optional if you are using localText for ag grid
+      hasApplyButton: true,
+    });
+
+    cy.get(agGridSelector)
+    .getAgGridData()
+    .then((actualTableData) => {
+      cy.agGridValidateRowsExactOrder(actualTableData, expectedTableData);
+    });
+
+  })
 
   it("verify paginated table data - any order - include all columns", () => {
     cy.get(agGridSelector).agGridValidatePaginatedTable(

--- a/cypress/fixtures/cardata.json
+++ b/cypress/fixtures/cardata.json
@@ -17,5 +17,6 @@
   { "Year": "2020", "Make": "Honda", "Model": "Accord", "Condition": "good", "Price": "34000" },
   { "Year": "1990", "Make": "Ford", "Model": "Taurus", "Condition": "excellent", "Price": "900" },
   { "Year": "2020", "Make": "Hyundai", "Model": "Elantra", "Condition": "fair", "Price": "3000" },
-  { "Year": "2020", "Make": "BMW", "Model": "2002", "Condition": "excellent", "Price": "88001" }
+  { "Year": "2020", "Make": "BMW", "Model": "2002", "Condition": "excellent", "Price": "88001" },
+  { "Year": "2020", "Make": "Toyota", "Model": "Celica", "Condition": "fair", "Price": "35000" }
 ]

--- a/src/agGrid/agGridInteractions.js
+++ b/src/agGrid/agGridInteractions.js
@@ -100,6 +100,14 @@ function _getAgGrid(agGridElement, options = {}, returnElements) {
     return ele.length;
   });
 
+  // Remove duplicate entries from allRows
+  // In some instances we see cell duplication for non-unique rows
+  allRows = allRows.map((row)=>{
+    return row.filter((cell, index)=>{
+      return row.indexOf(cell) === index;
+    })
+  })
+
   if (!allRows.length) rows = [];
   else {
     rows = allRows


### PR DESCRIPTION
With the new updates to support pinned columns, there was a bug introduced where we were returning duplicate entries when capturing ag grid data.